### PR TITLE
Added support for configuring 'scenario'

### DIFF
--- a/win11toast.py
+++ b/win11toast.py
@@ -251,6 +251,7 @@ def notify(title=None, body=None, on_click=print, icon=None, image=None, progres
 
     if duration:
         set_attribute(document, '/toast', 'duration', duration)
+
     if title:
         add_text(title, document)
     if body:

--- a/win11toast.py
+++ b/win11toast.py
@@ -13,7 +13,7 @@ from winsdk.windows.ui.notifications import (
 DEFAULT_APP_ID = 'Python'
 
 xml = """
-<toast activationType="protocol" launch="http:">
+<toast activationType="protocol" launch="http:" scenario="{scenario}">
     <visual>
         <binding template='ToastGeneric'></binding>
     </visual>
@@ -243,16 +243,13 @@ def available_recognizer_languages():
     print('Add-WindowsCapability -Online -Name "Language.OCR~~~en-US~0.0.1.0"')
 
 
-def notify(title=None, body=None, on_click=print, icon=None, image=None, progress=None, audio=None, dialogue=None, duration=None, input=None, inputs=[], selection=None, selections=[], button=None, buttons=[], xml=xml, app_id=DEFAULT_APP_ID):
+def notify(title=None, body=None, on_click=print, icon=None, image=None, progress=None, audio=None, dialogue=None, duration=None, input=None, inputs=[], selection=None, selections=[], button=None, buttons=[], xml=xml, app_id=DEFAULT_APP_ID, scenario=None):
     document = XmlDocument()
-    document.load_xml(xml)
-
+    document.load_xml(xml.format(scenario=scenario if scenario else 'default'))
     if isinstance(on_click, str):
         set_attribute(document, '/toast', 'launch', on_click)
-
     if duration:
         set_attribute(document, '/toast', 'duration', duration)
-
     if title:
         add_text(title, document)
     if body:
@@ -307,7 +304,7 @@ def notify(title=None, body=None, on_click=print, icon=None, image=None, progres
     return notification
 
 
-async def toast_async(title=None, body=None, on_click=print, icon=None, image=None, progress=None, audio=None, dialogue=None, duration=None, input=None, inputs=[], selection=None, selections=[], button=None, buttons=[], xml=xml, app_id=DEFAULT_APP_ID, ocr=None, on_dismissed=print, on_failed=print):
+async def toast_async(title=None, body=None, on_click=print, icon=None, image=None, progress=None, audio=None, dialogue=None, duration=None, input=None, inputs=[], selection=None, selections=[], button=None, buttons=[], xml=xml, app_id=DEFAULT_APP_ID, ocr=None, on_dismissed=print, on_failed=print, scenario=None):
     """
     Notify
     Args:
@@ -333,7 +330,7 @@ async def toast_async(title=None, body=None, on_click=print, icon=None, image=No
         src = ocr if isinstance(ocr, str) else ocr['ocr']
         image = {'placement': 'hero', 'src': src}
     notification = notify(title, body, on_click, icon, image,
-                          progress, audio, dialogue, duration, input, inputs, selection, selections, button, buttons, xml, app_id)
+                          progress, audio, dialogue, duration, input, inputs, selection, selections, button, buttons, xml, app_id,scenario)
     loop = asyncio.get_running_loop()
     futures = []
 

--- a/win11toast.py
+++ b/win11toast.py
@@ -13,7 +13,7 @@ from winsdk.windows.ui.notifications import (
 DEFAULT_APP_ID = 'Python'
 
 xml = """
-<toast activationType="protocol" launch="http:" scenario="{scenario}">
+<toast activationType="protocol" launch="http:">
     <visual>
         <binding template='ToastGeneric'></binding>
     </visual>
@@ -243,13 +243,16 @@ def available_recognizer_languages():
     print('Add-WindowsCapability -Online -Name "Language.OCR~~~en-US~0.0.1.0"')
 
 
-def notify(title=None, body=None, on_click=print, icon=None, image=None, progress=None, audio=None, dialogue=None, duration=None, input=None, inputs=[], selection=None, selections=[], button=None, buttons=[], xml=xml, app_id=DEFAULT_APP_ID, scenario=None):
+def notify(title=None, body=None, on_click=print, icon=None, image=None, progress=None, audio=None, dialogue=None, duration=None, input=None, inputs=[], selection=None, selections=[], button=None, buttons=[], xml=xml, app_id=DEFAULT_APP_ID):
     document = XmlDocument()
-    document.load_xml(xml.format(scenario=scenario if scenario else 'default'))
+    document.load_xml(xml)
+
     if isinstance(on_click, str):
         set_attribute(document, '/toast', 'launch', on_click)
+
     if duration:
         set_attribute(document, '/toast', 'duration', duration)
+
     if title:
         add_text(title, document)
     if body:
@@ -304,7 +307,7 @@ def notify(title=None, body=None, on_click=print, icon=None, image=None, progres
     return notification
 
 
-async def toast_async(title=None, body=None, on_click=print, icon=None, image=None, progress=None, audio=None, dialogue=None, duration=None, input=None, inputs=[], selection=None, selections=[], button=None, buttons=[], xml=xml, app_id=DEFAULT_APP_ID, ocr=None, on_dismissed=print, on_failed=print, scenario=None):
+async def toast_async(title=None, body=None, on_click=print, icon=None, image=None, progress=None, audio=None, dialogue=None, duration=None, input=None, inputs=[], selection=None, selections=[], button=None, buttons=[], xml=xml, app_id=DEFAULT_APP_ID, ocr=None, on_dismissed=print, on_failed=print):
     """
     Notify
     Args:
@@ -330,7 +333,7 @@ async def toast_async(title=None, body=None, on_click=print, icon=None, image=No
         src = ocr if isinstance(ocr, str) else ocr['ocr']
         image = {'placement': 'hero', 'src': src}
     notification = notify(title, body, on_click, icon, image,
-                          progress, audio, dialogue, duration, input, inputs, selection, selections, button, buttons, xml, app_id,scenario)
+                          progress, audio, dialogue, duration, input, inputs, selection, selections, button, buttons, xml, app_id)
     loop = asyncio.get_running_loop()
     futures = []
 

--- a/win11toast.py
+++ b/win11toast.py
@@ -248,6 +248,7 @@ def notify(title=None, body=None, on_click=print, icon=None, image=None, progres
     document.load_xml(xml.format(scenario=scenario if scenario else 'default'))
     if isinstance(on_click, str):
         set_attribute(document, '/toast', 'launch', on_click)
+
     if duration:
         set_attribute(document, '/toast', 'duration', duration)
     if title:

--- a/win11toast.py
+++ b/win11toast.py
@@ -246,10 +246,13 @@ def available_recognizer_languages():
 def notify(title=None, body=None, on_click=print, icon=None, image=None, progress=None, audio=None, dialogue=None, duration=None, input=None, inputs=[], selection=None, selections=[], button=None, buttons=[], xml=xml, app_id=DEFAULT_APP_ID, scenario=None):
     document = XmlDocument()
     document.load_xml(xml.format(scenario=scenario if scenario else 'default'))
+
     if isinstance(on_click, str):
         set_attribute(document, '/toast', 'launch', on_click)
+
     if duration:
         set_attribute(document, '/toast', 'duration', duration)
+        
     if title:
         add_text(title, document)
     if body:

--- a/win11toast.py
+++ b/win11toast.py
@@ -246,13 +246,10 @@ def available_recognizer_languages():
 def notify(title=None, body=None, on_click=print, icon=None, image=None, progress=None, audio=None, dialogue=None, duration=None, input=None, inputs=[], selection=None, selections=[], button=None, buttons=[], xml=xml, app_id=DEFAULT_APP_ID, scenario=None):
     document = XmlDocument()
     document.load_xml(xml.format(scenario=scenario if scenario else 'default'))
-
     if isinstance(on_click, str):
         set_attribute(document, '/toast', 'launch', on_click)
-
     if duration:
         set_attribute(document, '/toast', 'duration', duration)
-        
     if title:
         add_text(title, document)
     if body:


### PR DESCRIPTION
Sorry for the messy commit history, just made a few small changes to enable configuring the 'scenario' field via this package (I needed toasts to not disappear after a timeout, and this looked like the easiest way to do that.)