### PR TITLE
fix TypeError: 'winrt._winrt_windows_foundation_collections.ValueSet'…

### DIFF
--- a/win11toast.py
+++ b/win11toast.py
@@ -166,7 +166,7 @@ def activated_args(_, event):
     global result
     e = ToastActivatedEventArgs._from(event)
     user_input = dict([(name, IPropertyValue._from(
-        e.user_input[name]).get_string()) for name in e.user_input()])
+        e.user_input[name]).get_string()) for name in e.user_input])
     result = {
         'arguments': e.arguments,
         'user_input': user_input
@@ -393,7 +393,6 @@ async def toast_async(title=None, body=None, on_click=print, icon=None, image=No
             notification.remove_dismissed(dismissed_token)
         if failed_token is not None:
             notification.remove_failed(failed_token)
-        return result
 
 
 def toast(*args, **kwargs):


### PR DESCRIPTION
… object is not callable & Python version 3.14 does not support the use of 'return' inside a 'finally' clause.

details in issue #56 