### PR TITLE
Fix syntax error in user_input dictionary comprehension

### DIFF
--- a/win11toast.py
+++ b/win11toast.py
@@ -166,7 +166,7 @@ def activated_args(_, event):
     global result
     e = ToastActivatedEventArgs._from(event)
     user_input = dict([(name, IPropertyValue._from(
-        e.user_input[name]).get_string()) for name in e.user_input()])
+        e.user_input[name]).get_string()) for name in e.user_input])
     result = {
         'arguments': e.arguments,
         'user_input': user_input


### PR DESCRIPTION
Using the callback example in the readme
```python
from win11toast import toast

toast('Hello Python', 'Click to open url', on_click=lambda args: print('clicked!', args))
```

Raises:
```
File "win11toast.py", line 169, in activated_args
    e.user_input[name]).get_string()) for name in e.user_input()])
                                                  ^^^^^^^^^^^^^^
TypeError: 'winrt._winrt_windows_foundation_collections.ValueSet' object is not callable
```

This corrects that error by removing the extra `()` in `e.user_input()`. See also #56 and #57.