### PR TITLE
Remove unexpected return value in function toast_async

### DIFF
--- a/win11toast.py
+++ b/win11toast.py
@@ -166,7 +166,7 @@ def activated_args(_, event):
     global result
     e = ToastActivatedEventArgs._from(event)
     user_input = dict([(name, IPropertyValue._from(
-        e.user_input[name]).get_string()) for name in e.user_input()])
+        e.user_input[name]).get_string()) for name in e.user_input])
     result = {
         'arguments': e.arguments,
         'user_input': user_input
@@ -393,7 +393,6 @@ async def toast_async(title=None, body=None, on_click=print, icon=None, image=No
             notification.remove_dismissed(dismissed_token)
         if failed_token is not None:
             notification.remove_failed(failed_token)
-        return result
 
 
 def toast(*args, **kwargs):


### PR DESCRIPTION
`return result` at pos2 should be removed as:
1. docstring at pos1 claims return `None`
2. the use of 'return' inside a 'finally' clause is not supported in Python version 3.14
3. `result` is a global viriable and is not used directly in this function

```py
async def toast_async(...):
    """
    Notify
    Args:
        ...
    Returns:
        None  <-- pos1
    """
    ...
    try:
        _, pending = await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
        for p in pending:
            p.cancel()
    finally:
        if activated_token is not None:
            notification.remove_activated(activated_token)
        if dismissed_token is not None:
            notification.remove_dismissed(dismissed_token)
        if failed_token is not None:
            notification.remove_failed(failed_token)
        return result  <-- pos2
```